### PR TITLE
change the 🕵️‍♀️ license to dontpanicdao

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Gregory Guillou
+Copyright (c) 2022 Don't Panic DAO
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ help developers to participate with Hackathons. The project includes:
 - [argent](https://twitter.com/argentHQ) for the fantastic work they do daily
   to bring Argent-X to starknet and work with Starkware and the community to
   build a better future.
-- [@crema](https://twitter.com/crema_fr) for helping starting the project and
-  providing the support I needed
+- [@crema](https://twitter.com/crema_fr) and
+  [@DrSpacemn](https://twitter.com/DrSpacemn) for helping starting the project
+  and providing some support.
 - [0xs34n](https://twitter.com/0xs34n) from 
   [aspect.co](https://twitter.com/aspectdotco) for building and maintaining
   [starknet-js](https://github.com/0xs34n/starknet.js).
+


### PR DESCRIPTION
This PR changes the License and the README to reference [Don't Panic DAO](https://github.com/dontpanicdao)
