### PR TITLE
fix 🤬 issue with key renewal on the burner

### DIFF
--- a/burner/src/lib/Burner.svelte
+++ b/burner/src/lib/Burner.svelte
@@ -40,7 +40,7 @@
 		<h3 class="subtitle">Powered by</h3>
 		<div class="icon-wrapper"><StarknetIcon /></div>
 	</div>
-	{#if !$wallet.isLoggedIn}
+	{#if !$burner.isLoggedIn}
 		<div class="lds-hourglass" />
 	{:else if $burner.state == 'renewkey'}
 		<RenewKeys />
@@ -86,17 +86,6 @@
 </div>
 
 <style>
-	.star {
-		position: absolute;
-		width: 2px;
-		height: 2px;
-		background: rgba(255, 255, 255, 0);
-		border-radius: 5px;
-		animation-name: twinkle;
-		animation-timing-function: ease-in;
-		animation-iteration-count: infinite;
-	}
-
 	@keyframes twinkle {
 		0% {
 			transform: scale(1, 1);

--- a/burner/src/lib/RegisterKeys.svelte
+++ b/burner/src/lib/RegisterKeys.svelte
@@ -6,28 +6,11 @@
 	import { onMount } from 'svelte';
 	import CopyIcon from '$lib/icons/CopyIcon.svelte';
 
-	let publicKey = '';
-	let expires = 0;
-	let token1 = '';
-	let token2 = '';
-	let account = '';
-	let errMessage = '';
-
 	const cancel = () => {
 		setState('view');
 	};
 
-	const save = () => {
-		if (!account) {
-			errMessage = 'Enter an account';
-			return;
-		}
-		const history: Txn[] = [];
-		saveToken(account, expires, token1, token2, history);
-		setState('view');
-	};
-
-	const copyInClipBoard = async (value) => {
+	const copyInClipBoard = async (value: string) => {
 		const elem = document.createElement('textarea');
 		elem.value = value;
 		document.body.appendChild(elem);
@@ -38,15 +21,6 @@
 
 	onMount(() => {
 		loadKeys();
-		wallet.subscribe((data) => {
-			publicKey = data.token.sessionkey;
-			expires = data.token.expires;
-			if (data.token.token.length >= 2) {
-				token1 = data.token.token[0];
-				token2 = data.token.token[1];
-			}
-			account = data.token.account;
-		});
 	});
 </script>
 
@@ -58,13 +32,13 @@
 			type="text"
 			class="key"
 			placeholder="0x..."
-			bind:value={publicKey}
+			value={$wallet.token?.sessionkey}
 			disabled
 		/>
 		<button
 			class="secondary"
 			on:click={() => {
-				copyInClipBoard(publicKey);
+				copyInClipBoard($wallet.token?.sessionkey);
 			}}
 		>
 			<CopyIcon />
@@ -78,27 +52,47 @@
 		}}>Change</button
 	>
 	<label style="margin-top: 20px" for="account">account</label>
-	<input id="account" type="text" class="key" placeholder="0x..." bind:value={account} />
+	<input
+		id="account"
+		disabled
+		type="text"
+		class="key"
+		placeholder="0x..."
+		value={$wallet.token?.account}
+	/>
 	<label for="expires">expires</label>
-	<input id="expires" type="text" class="key" placeholder="" bind:value={expires} />
+	<input
+		id="expires"
+		disabled
+		type="text"
+		class="key"
+		placeholder=""
+		value={$wallet.token?.expires}
+	/>
 	<label for="token1">session token (#1)</label>
-	<input id="token1" type="text" class="key" placeholder="0x..." bind:value={token1} />
+	<input
+		id="token1"
+		disabled
+		type="text"
+		class="key"
+		placeholder="0x..."
+		value={$wallet.token?.token[0]}
+	/>
 	<label for="token2">session token (#2)</label>
-	<input id="token2" type="text" class="key" placeholder="0x..." bind:value={token2} />
-	{#if errMessage}
-		<div class="error">{errMessage}</div>
-	{/if}
+	<input
+		id="token2"
+		disabled
+		type="text"
+		class="key"
+		placeholder="0x..."
+		value={$wallet.token?.token[1]}
+	/>
 	<div class="command">
-		<button class="secondary" on:click={cancel}>Cancel</button>
-		<button on:click={save}>Save</button>
+		<button class="secondary" on:click={cancel}>Back</button>
 	</div>
 </div>
 
 <style>
-	.error {
-		text-align: center;
-		color: crimson;
-	}
 	.key {
 		min-width: 70%;
 		height: 1em;

--- a/burner/src/lib/RenewKeys.svelte
+++ b/burner/src/lib/RenewKeys.svelte
@@ -2,15 +2,10 @@
 	import { setState } from '$lib/stores/burner';
 	import QR from '$lib/QR.svelte';
 	import { wallet, renewSessionKey } from '$lib/stores/wallet';
-	import { red } from 'bn.js';
 
 	const baseURL = import.meta.env.VITE_DRONE_BASEURL || 'http://localhost:5173';
 	const back = () => {
 		setState('keys');
-	};
-
-	const renew = () => {
-		renewSessionKey();
 	};
 </script>
 
@@ -23,7 +18,7 @@
 	</div>
 	<div class="command">
 		<button class="secondary" on:click={back}>Back...</button>
-		<button on:click={renew}>Renew</button>
+		<button on:click={renewSessionKey}>Renew</button>
 	</div>
 </div>
 

--- a/burner/src/lib/Send.svelte
+++ b/burner/src/lib/Send.svelte
@@ -5,7 +5,7 @@
 	import Scanner from './Scanner.svelte';
 	import ScanIcon from './ScanIcon.svelte';
 
-	let to = '';
+	let to = '0x0207aCC15dc241e7d167E67e30E769719A727d3E0fa47f9E187707289885Dfde';
 	let amount = 1;
 	let errMessage = '';
 	let displayScan = false;

--- a/burner/src/lib/stores/burner.ts
+++ b/burner/src/lib/stores/burner.ts
@@ -19,5 +19,6 @@ export const track = (loading: boolean, lastError: string) => {
 export const burner = writable({
 	lastError: '',
 	loading: false,
-	state: 'view'
+	state: 'view',
+	isLoggedIn: false
 });

--- a/burner/src/lib/stores/wallet.ts
+++ b/burner/src/lib/stores/wallet.ts
@@ -39,8 +39,7 @@ export const saveToken = async (
 		return {
 			...data,
 			token,
-			history: tx,
-			isLoggedIn: true
+			history: tx
 		};
 	});
 };
@@ -51,16 +50,11 @@ export const renewSessionKey = () => {
 		throw new Error('failed to generate key');
 	}
 	localStorage.setItem('bwpk', pk);
-	let token = localStorage.getItem('bwtk');
-	if (!token || token === '') {
-		return;
-	}
-	let tokenData = JSON.parse(token);
 	localStorage.setItem(
 		'bwtk',
 		JSON.stringify({
 			sessionkey: publicKey as string,
-			account: tokenData.account,
+			account: '',
 			expires: 0,
 			token: [] as string[]
 		})
@@ -70,7 +64,7 @@ export const renewSessionKey = () => {
 			...data,
 			token: {
 				sessionkey: publicKey as string,
-				account: tokenData.account,
+				account: '',
 				expires: 0,
 				token: [] as string[]
 			}
@@ -240,7 +234,6 @@ export const refreshTxn = async (hash: string) => {
 export const wallet = writable({
 	lastError: null,
 	loading: false,
-	isLoggedIn: false,
 	token: {
 		sessionkey: '',
 		account: '',

--- a/burner/src/lib/ts/keys.ts
+++ b/burner/src/lib/ts/keys.ts
@@ -2,6 +2,7 @@ import { ec } from 'starknet';
 import { toBN } from 'starknet/utils/number';
 import type { Txn } from '$lib/ts/txns';
 import { wallet } from '$lib/stores/wallet';
+import { burner } from '$lib/stores/burner';
 
 export const loadKeys = () => {
 	let sessPrivateKey = localStorage.getItem('bwpk');
@@ -28,9 +29,10 @@ export const loadKeys = () => {
 			return {
 				...data,
 				token,
-				isLoggedIn: true
+				history: [] as Txn[]
 			};
 		});
+		burner.update((data) => ({ ...data, isLoggedIn: true }));
 		return;
 	}
 	let tokenData = JSON.parse(bwtk);
@@ -50,10 +52,10 @@ export const loadKeys = () => {
 		return {
 			...data,
 			token,
-			history,
-			isLoggedIn: true
+			history
 		};
 	});
+	burner.update((data) => ({ ...data, isLoggedIn: true }));
 	return;
 };
 


### PR DESCRIPTION
## Associated issue
I have detected and not reported an issue on key renewal. This PR should fix it

## Description
- The page navigation was based on the `wallet` when it should have been based on the `burner` store. I have corrected it
- For some reasons, the account was not cleaned which resulted in the page opening on the view despite token not beeing filed after a renew. It should be corrected


