### PR TITLE
fix third party data 👻 in a session when blocked

### DIFF
--- a/burner-next/wallet/lib/handleLocalStorage.js
+++ b/burner-next/wallet/lib/handleLocalStorage.js
@@ -4,8 +4,7 @@ const getLocalStorage = (keyName) => {
   try {
     return sessionStorage.getItem(keyName);
   } catch (e) {
-    console.log("sessionStorage unavailable, working with variable");
-    return sessionData?.[keyName];
+    return sessionData[keyName];
   }
 };
 
@@ -14,7 +13,8 @@ const saveLocalStorage = (keyName, value) => {
     return sessionStorage.setItem(keyName, value);
   } catch (e) {
     console.log("sessionStorage unavailable, working with variable");
-    return (sessionData[keyName] = value);
+    sessionData[keyName] = value;
+    return;
   }
 };
 
@@ -22,9 +22,8 @@ const removeLocalStorage = () => {
   try {
     return sessionStorage.clear();
   } catch (e) {
-    console.log("sessionStorage unavailable, working with variable");
     for (const keyName of sessionData) {
-      delete sessionData?.[keyName];
+      delete sessionData[keyName];
     }
   }
 };


### PR DESCRIPTION
This is the case, for instance, by default when you move to incognito mode. When that is the case, `sessionStorage` is not available for 3rd party site, i.e for the burner since it is stored in a different origin. Note that it has nothing to do with preventing tracker accross session because we already do not use the localStorage api. 

For now the way we have fixed this issue is by catching the exception and relying on a variable. If that is good enough for a number of situations, it cannot work for real use cases and we will have to investigate better issue, including I am afraid, being part of the primary site
