### PR TITLE
implement the account 🦆 request/response

### DIFF
--- a/burner/extension/package.json
+++ b/burner/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@starknet/burner",
   "private": false,
-  "version": "0.2.99",
+  "version": "0.2.100",
   "description": "A burner for Starknet",
   "type": "module",
   "files": [

--- a/burner/extension/src/components/button.ts
+++ b/burner/extension/src/components/button.ts
@@ -17,7 +17,7 @@ export const injectButton = (): any => {
   const handleButtonClick = () => {
     const iFramePosition = iFrame.getBoundingClientRect();
     sendMessage({
-      type: clicked ? "CLOSE_MODAL" : "OPEN_MODAL",
+      type: clicked ? "keyring_CloseModal" : "keyring_OpenModal",
     });
     const { top, left, width, height } = iFramePosition;
     const iFrameTop = top + height * 0.025;

--- a/burner/extension/src/lib/inpage/account.ts
+++ b/burner/extension/src/lib/inpage/account.ts
@@ -1,164 +1,52 @@
-import { BigNumberish, toBN } from "starknet/utils/number";
 import { AccountInterface } from "starknet/account/interface";
 import {
-  EstimateFeeResponse,
-  GetCodeResponse,
-  InvokeFunctionResponse,
-  GetTransactionResponse,
-  GetBlockResponse,
-  ContractClass,
-  InvokeTransactionReceiptResponse,
-  DeployContractResponse,
-  DeclareContractResponse,
-} from "starknet/types";
-
+  estimateFee,
+  execute,
+  signMessage,
+  hashMessage,
+  verifyMessage,
+  verifyMessageHash,
+  getNonce,
+} from "../messages";
 import { signer } from "./signer";
 import { StarknetChainId } from "starknet/constants";
-import { callContract } from "../messages/provider";
+import { provider } from "./provider";
+const {
+  callContract,
+  getBlock,
+  getCode,
+  getClassAt,
+  getEstimateFee,
+  getStorageAt,
+  getTransaction,
+  getTransactionReceipt,
+  invokeFunction,
+  deployContract,
+  declareContract,
+  waitForTransaction,
+} = provider;
 
 export const account: AccountInterface = {
   signer,
   chainId: StarknetChainId.TESTNET,
-  estimateFee: async (calls, EstimateFeeDetails) => {
-    console.log("calls", calls);
-    console.log("EstimateFeeDetails", EstimateFeeDetails);
-    const response: EstimateFeeResponse = {
-      overall_fee: "0",
-      gas_consumed: "0",
-      gas_price: "0",
-    };
-    return Promise.resolve(response);
-  },
-  address: "0x0",
-  getNonce: async () => {
-    return Promise.resolve("0");
-  },
-  execute: async (call, abis, invocationsDetails) => {
-    console.log("call", call);
-    console.log("abis", abis);
-    console.log("invocationsDetails", invocationsDetails);
-    const response: InvokeFunctionResponse = {
-      transaction_hash: "0x0",
-    };
-    return Promise.resolve(response);
-  },
-  signMessage: async (typedData) => {
-    console.log("typedData", typedData);
-    return await signer.signMessage(typedData, account.address);
-  },
-  hashMessage: async (message) => {
-    console.log("message", message);
-    return Promise.resolve("0x0");
-  },
-  verifyMessage: async (typedData, signature) => {
-    console.log("typedData", typedData);
-    console.log("signature", signature);
-    return Promise.resolve(true);
-  },
-  verifyMessageHash: async (hash, signature) => {
-    console.log("hash", hash);
-    console.log("signature", signature);
-    return Promise.resolve(true);
-  },
+  address: "",
+  estimateFee,
+  execute,
+  signMessage,
+  hashMessage,
+  verifyMessage,
+  verifyMessageHash,
+  getNonce,
   callContract,
-  getCode: async (address, blockIdentifier) => {
-    console.log("address", address);
-    console.log("blockIdentifier", blockIdentifier);
-    const response: GetCodeResponse = {
-      bytecode: ["0x0"],
-    };
-    return Promise.resolve(response);
-  },
-  getBlock: async (blockIdentifier) => {
-    console.log("blockIdentifier", blockIdentifier);
-    const out: GetBlockResponse = {
-      accepted_time: 1599098983,
-      block_hash:
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-      block_number: 1,
-      gas_price: "0x1",
-      new_root:
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-      parent_hash:
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-      sequencer:
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-      status: "REJECTED",
-      transactions: [],
-    };
-    return Promise.resolve(out);
-  },
-  getClassAt: async (contractAddress, blockIdentifier) => {
-    console.log("contractAddress", contractAddress);
-    console.log("blockIdentifier", blockIdentifier);
-    const response: ContractClass = {
-      program: "0x0",
-      entry_points_by_type: {},
-    };
-    return Promise.resolve(response);
-  },
-  getEstimateFee: async (invocation, blockIdentifier, details) => {
-    console.log("invocation", invocation);
-    console.log("blockIdentifier", blockIdentifier);
-    console.log("details", details);
-    const response: EstimateFeeResponse = {
-      overall_fee: toBN(0),
-      gas_consumed: toBN(0),
-      gas_price: toBN(0),
-    };
-    return Promise.resolve(response);
-  },
-  getStorageAt: async (contractAddress, key, blockIdentifier) => {
-    console.log("contractAddress", contractAddress);
-    console.log("key", key);
-    console.log("blockIdentifier", blockIdentifier);
-    const response: BigNumberish = key;
-    return Promise.resolve(response);
-  },
-  getTransaction: async (transactionHash) => {
-    console.log("transactionHash", transactionHash);
-    const response: GetTransactionResponse = {
-      calldata: [],
-    };
-    return Promise.resolve(response);
-  },
-  getTransactionReceipt: async (transactionHash) => {
-    console.log("transactionHash", transactionHash);
-    const response: InvokeTransactionReceiptResponse = {
-      messages_sent: [],
-      transaction_hash: "0x0",
-      events: [],
-      status: "REJECTED",
-    };
-    return Promise.resolve(response);
-  },
-  invokeFunction: async (invocation, details) => {
-    console.log("invocation", invocation);
-    console.log("details", details);
-    const response: InvokeFunctionResponse = {
-      transaction_hash: "0x0",
-    };
-    return Promise.resolve(response);
-  },
-  deployContract: async (payload) => {
-    console.log("payload", payload);
-    const response: DeployContractResponse = {
-      transaction_hash: "0x0",
-      contract_address: "0x0",
-    };
-    return Promise.resolve(response);
-  },
-  declareContract: async (payload) => {
-    console.log("payload", payload);
-    const response: DeclareContractResponse = {
-      transaction_hash: "0x0",
-      class_hash: "0x0",
-    };
-    return Promise.resolve(response);
-  },
-  waitForTransaction: async (txHash, retryInterval) => {
-    console.log("txHash", txHash);
-    console.log("retryInterval", retryInterval);
-    return Promise.resolve();
-  },
+  getCode,
+  getClassAt,
+  getEstimateFee,
+  getStorageAt,
+  getTransaction,
+  getTransactionReceipt,
+  getBlock,
+  invokeFunction,
+  deployContract,
+  declareContract,
+  waitForTransaction,
 };

--- a/burner/extension/src/lib/messages/account.ts
+++ b/burner/extension/src/lib/messages/account.ts
@@ -165,6 +165,7 @@ export const verifyMessageHash = async (
   });
   return await waitForMessage("account_VerifyMessageHashResponse");
 };
+
 export const getNonce = async (): Promise<string> => {
   sendMessage({
     type: "account_GetNonce",

--- a/burner/extension/src/lib/messages/account.ts
+++ b/burner/extension/src/lib/messages/account.ts
@@ -1,0 +1,173 @@
+import {
+  EstimateFeeResponse,
+  InvokeFunctionResponse,
+  Signature,
+} from "starknet";
+import type {
+  Call,
+  EstimateFeeDetails,
+  Abi,
+  InvocationsDetails,
+} from "starknet";
+import { BigNumberish } from "starknet/utils/number";
+
+import { sendMessage, waitForMessage } from "./index";
+import { TypedData } from "starknet/utils/typedData";
+
+type EstimateFeeRequest = {
+  calls: Call | Call[];
+  estimateFeeDetails: EstimateFeeDetails;
+};
+
+type ExecuteRequest = {
+  transactions: Call | Call[];
+  abis?: Abi[];
+  transactionsDetail?: InvocationsDetails;
+};
+
+type VerifyMessageRequest = {
+  typedData: TypedData;
+  signature: Signature;
+};
+
+type VerifyMessageHashRequest = {
+  hash: BigNumberish;
+  signature: Signature;
+};
+
+export type AccountMessage =
+  | {
+      type: "account_EstimateFee";
+      data: EstimateFeeRequest;
+    }
+  | {
+      type: "account_EstimateFeeResponse";
+      data: EstimateFeeResponse;
+    }
+  | {
+      type: "account_Execute";
+      data: ExecuteRequest;
+    }
+  | {
+      type: "account_ExecuteResponse";
+      data: InvokeFunctionResponse;
+    }
+  | {
+      type: "account_SignMessage";
+      data: TypedData;
+    }
+  | {
+      type: "account_SignMessageResponse";
+      data: Signature;
+    }
+  | {
+      type: "account_HashMessage";
+      data: TypedData;
+    }
+  | {
+      type: "account_HashMessageResponse";
+      data: string;
+    }
+  | {
+      type: "account_VerifyMessage";
+      data: VerifyMessageRequest;
+    }
+  | {
+      type: "account_VerifyMessageResponse";
+      data: boolean;
+    }
+  | {
+      type: "account_VerifyMessageHash";
+      data: VerifyMessageHashRequest;
+    }
+  | {
+      type: "account_VerifyMessageHashResponse";
+      data: boolean;
+    }
+  | {
+      type: "account_GetNonce";
+    }
+  | {
+      type: "account_GetNonceResponse";
+      data: string;
+    };
+
+export const estimateFee = async (
+  calls: Call | Call[],
+  estimateFeeDetails: EstimateFeeDetails
+): Promise<EstimateFeeResponse> => {
+  sendMessage({
+    type: "account_EstimateFee",
+    data: {
+      calls,
+      estimateFeeDetails,
+    },
+  });
+  return await waitForMessage("account_EstimateFeeResponse");
+};
+
+export const execute = async (
+  transactions: Call | Call[],
+  abis?: Abi[],
+  transactionsDetail?: InvocationsDetails
+): Promise<InvokeFunctionResponse> => {
+  sendMessage({
+    type: "account_Execute",
+    data: {
+      transactions,
+      abis,
+      transactionsDetail,
+    },
+  });
+  return await waitForMessage("account_ExecuteResponse");
+};
+
+export const signMessage = async (typedData: TypedData): Promise<Signature> => {
+  sendMessage({
+    type: "account_SignMessage",
+    data: typedData,
+  });
+  return await waitForMessage("account_SignMessageResponse");
+};
+
+export const hashMessage = async (typedData: TypedData): Promise<string> => {
+  sendMessage({
+    type: "account_HashMessage",
+    data: typedData,
+  });
+  return await waitForMessage("account_HashMessageResponse");
+};
+
+export const verifyMessage = async (
+  typedData: TypedData,
+  signature: Signature
+): Promise<boolean> => {
+  sendMessage({
+    type: "account_VerifyMessage",
+    data: {
+      typedData,
+      signature,
+    },
+  });
+  return await waitForMessage("account_VerifyMessageResponse");
+};
+
+export const verifyMessageHash = async (
+  hash: BigNumberish,
+  signature: Signature
+): Promise<boolean> => {
+  sendMessage({
+    type: "account_VerifyMessageHash",
+    data: {
+      hash,
+      signature,
+    },
+  });
+  return await waitForMessage("account_VerifyMessageHashResponse");
+};
+export const getNonce = async (): Promise<string> => {
+  sendMessage({
+    type: "account_GetNonce",
+  });
+  return await waitForMessage("account_GetNonceResponse");
+};

--- a/burner/extension/src/lib/messages/global.ts
+++ b/burner/extension/src/lib/messages/global.ts
@@ -29,12 +29,12 @@ export const extensionEventHandler = (event: MessageEvent) => {
       break;
     case "keyring_OpenModal":
       break;
-    case "CLOSE_MODAL":
+    case "keyring_CloseModal":
       break;
-    case "CALL_CONTRACT_RES":
+    case "provider_CallContractResponse":
       break;
     default:
-      console.log("in:extension", "umknown event", type);
+      console.log("in:extension", "unknown event", type);
       break;
   }
 };

--- a/burner/extension/src/lib/messages/global.ts
+++ b/burner/extension/src/lib/messages/global.ts
@@ -2,19 +2,19 @@ import { uuid } from "./index";
 
 export type GlobalMessage =
   | {
-      type: "PING";
+      type: "keyring_Ping";
       data: string;
     }
   | {
-      type: "PONG";
+      type: "keyring_Pong";
       data: string;
     }
   | {
-      type: "OPEN_MODAL";
+      type: "keyring_OpenModal";
       data?: string;
     }
   | {
-      type: "CLOSE_MODAL";
+      type: "keyring_CloseModal";
       data?: string;
     };
 
@@ -23,20 +23,18 @@ export const extensionEventHandler = (event: MessageEvent) => {
     return;
   }
   const { type, data } = event.data;
+  console.log("in:extension", type, data);
   switch (type) {
-    case "PONG":
-      console.log("in:extension", type, data);
+    case "keyring_Pong":
       break;
-    case "OPEN_MODAL":
-      console.log("in:extension", type, data);
+    case "keyring_OpenModal":
       break;
     case "CLOSE_MODAL":
-      console.log("in:extension", type, data);
       break;
     case "CALL_CONTRACT_RES":
       break;
     default:
-      console.log("in:extension", "unexpected event type", type);
+      console.log("in:extension", "umknown event", type);
       break;
   }
 };

--- a/burner/extension/src/lib/messages/index.ts
+++ b/burner/extension/src/lib/messages/index.ts
@@ -2,6 +2,16 @@ import { TransactionMessage } from "./transaction";
 import { ProviderMessage, callContract } from "./provider";
 import { extensionEventHandler, GlobalMessage } from "./global";
 import { ConfigMessage, WatchAssetParameters } from "./configuration";
+import {
+  AccountMessage,
+  estimateFee,
+  execute,
+  signMessage,
+  hashMessage,
+  verifyMessage,
+  verifyMessageHash,
+  getNonce,
+} from "./account";
 
 export const uuid = "589c80c1eb85413d";
 const defaultTimeoutMilliseconds = 5000;
@@ -10,7 +20,8 @@ export type MessageType =
   | TransactionMessage
   | ProviderMessage
   | GlobalMessage
-  | ConfigMessage;
+  | ConfigMessage
+  | AccountMessage;
 
 export type WindowMessageType = MessageType & {
   uuid: string;
@@ -53,4 +64,14 @@ export const waitForMessage = async <
 };
 
 export type { ConfigMessage, WatchAssetParameters };
-export { callContract, extensionEventHandler };
+export {
+  callContract,
+  extensionEventHandler,
+  estimateFee,
+  execute,
+  signMessage,
+  hashMessage,
+  verifyMessage,
+  verifyMessageHash,
+  getNonce,
+};

--- a/burner/extension/src/lib/messages/provider.ts
+++ b/burner/extension/src/lib/messages/provider.ts
@@ -12,19 +12,19 @@ export interface CallContractRequest {
 
 export type ProviderMessage =
   | {
-      type: "CALL_CONTRACT";
+      type: "provider_CallContract";
       data: CallContractRequest;
     }
   | {
-      type: "CALL_CONTRACT_RES";
+      type: "provider_CallContractResponse";
       data: CallContractResponse;
     }
   | {
-      type: "GET_BLOCK";
+      type: "provider_GetBlock";
       data: BlockIdentifier;
     }
   | {
-      type: "GET_BLOCK_RES";
+      type: "provider_GetBlockResponse";
       data: GetBlockResponse;
     };
 
@@ -33,23 +33,23 @@ export const callContract = async (
   blockIdentifier: BlockIdentifier = "pending"
 ): Promise<CallContractResponse> => {
   sendMessage({
-    type: "CALL_CONTRACT",
+    type: "provider_CallContract",
     data: {
       transactions: call,
       blockIdentifier,
     },
   });
-  return await waitForMessage("CALL_CONTRACT_RES");
+  return await waitForMessage("provider_CallContractResponse");
 };
 
 export const getBlock = async (
   blockIdentifier: BlockIdentifier = "pending"
 ): Promise<GetBlockResponse> => {
   sendMessage({
-    type: "GET_BLOCK",
+    type: "provider_GetBlock",
     data: {
       blockIdentifier,
     },
   });
-  return await waitForMessage("GET_BLOCK_RES");
+  return await waitForMessage("provider_GetBlockResponse");
 };

--- a/burner/keyring/lib/handlers/account.js
+++ b/burner/keyring/lib/handlers/account.js
@@ -1,0 +1,38 @@
+export const accountEventHandler = async (type, data) => {
+  switch (type) {
+    case "account_EstimateFee":
+      {
+        const { calls, estimateFeeDetails } = data;
+      }
+      break;
+    case "account_Execute":
+      {
+        const { transactions, abis, transactionsDetail } = data;
+      }
+      break;
+    case "account_SignMessage":
+      {
+        const typedData = data;
+      }
+      break;
+    case "account_HashMessage":
+      {
+        const typedData = data;
+      }
+      break;
+    case "account_VerifyMessage":
+      {
+        const { typedData, signature } = data;
+      }
+      break;
+    case "account_VerifyMessageHash":
+      {
+        const { hash, signature } = data;
+      }
+      break;
+    case "account_GetNonce":
+      break;
+    default:
+      break;
+  }
+};

--- a/burner/keyring/lib/handlers/account.js
+++ b/burner/keyring/lib/handlers/account.js
@@ -1,36 +1,93 @@
+import { Account, Signer, Provider, ec } from "starknet";
+
 export const accountEventHandler = async (type, data) => {
+  const sessionKey = getLocalStorage("bwsessionkey");
+  const token = getLocalStorage("bwsessiontoken");
+  const address = JSON.parse(token)?.account;
+  const keypair = ec.getKeyPair(sessionKey);
+  const signer = new Signer(keypair);
+  const provider = new Provider({ sequencer: { network: "alpha-goerli" } });
+  const account = new Account(provider, address, signer);
   switch (type) {
     case "account_EstimateFee":
       {
         const { calls, estimateFeeDetails } = data;
+        const estimateFeeResponse = await account.estimateFee(
+          calls,
+          estimateFeeDetails
+        );
+        notify({
+          type: "account_EstimateFeeResponse",
+          data: estimateFeeResponse,
+        });
       }
       break;
     case "account_Execute":
       {
         const { transactions, abis, transactionsDetail } = data;
+        // TODO: rewrite the transaction to rely on the plugin
+        const executeResponse = await account.execute(
+          transactions,
+          abis,
+          transactionsDetail
+        );
+        notify({ type: "account_ExecuteResponse", data: executeResponse });
       }
       break;
     case "account_SignMessage":
       {
         const typedData = data;
+        const signMessageResponse = await account.SignMessage(typedData);
+        notify({
+          type: "account_SignMessageResponse",
+          data: signMessageResponse,
+        });
       }
       break;
     case "account_HashMessage":
       {
         const typedData = data;
+        const hashMessageResponse = await account.HashMessage(typedData);
+        notify({
+          type: "account_HashMessageResponse",
+          data: hashMessageResponse,
+        });
       }
       break;
     case "account_VerifyMessage":
       {
         const { typedData, signature } = data;
+        const verifyMessageResponse = await account.VerifyMessage(
+          typedData,
+          signature
+        );
+        notify({
+          type: "account_VerifyMessageResponse",
+          data: verifyMessageResponse,
+        });
       }
       break;
     case "account_VerifyMessageHash":
       {
         const { hash, signature } = data;
+        const verifyMessageHashResponse = await account.VerifyMessageHash(
+          hash,
+          signature
+        );
+        notify({
+          type: "account_VerifyMessageHashResponse",
+          data: verifyMessageHashResponse,
+        });
       }
       break;
     case "account_GetNonce":
+      {
+        const getNonceResponse = await account.GetNonce();
+        notify({
+          type: "account_GetNonceResponse",
+          data: getNonceResponse,
+        });
+      }
       break;
     default:
       break;

--- a/burner/keyring/lib/handlers/keyring.js
+++ b/burner/keyring/lib/handlers/keyring.js
@@ -1,0 +1,19 @@
+import { notify, callBacks } from "../message";
+
+export const keyringEventHandler = async (type, data) => {
+  switch (type) {
+    case "keyring_Ping":
+      notify({ type: "keyring_Pong", data });
+      break;
+    case "keyring_OpenModal":
+      callBacks.setDisplay(true);
+      notify({ type: "keyring_OpenModal", data: "ack" });
+      break;
+    case "keyring_CloseModal":
+      callBacks.setDisplay(false);
+      notify({ type: "keyring_CloseModal", data: "ack" });
+      break;
+    default:
+      break;
+  }
+};

--- a/burner/keyring/lib/handlers/provider.js
+++ b/burner/keyring/lib/handlers/provider.js
@@ -1,0 +1,35 @@
+import { Provider } from "starknet/provider";
+import { toBN } from "starknet/utils/number";
+import { notify } from "../message";
+
+export const provider = new Provider({
+  sequencer: { network: "goerli-alpha" },
+});
+
+export const providerEventHandler = async (type, data) => {
+  switch (type) {
+    case "provider_CallContract":
+      {
+        const { transactions, blockIdentifier } = data;
+        const { contractAddress, entrypoint, calldata } = transactions;
+        const newCall = {
+          contractAddress,
+          entrypoint,
+          calldata: [...calldata.map((v) => toBN(v).toString(10))],
+        };
+        console.log(newCall);
+        const output = await provider.callContract(newCall, blockIdentifier);
+        notify({ type: "provider_CallContractResponse", data: output });
+      }
+      break;
+    case "provider_GetBlock":
+      {
+        const { blockIdentifier } = data;
+        const output = await provider.getBlock(blockIdentifier);
+        notify({ type: "provider_GetBlockResponse", data: output });
+      }
+      break;
+    default:
+      break;
+  }
+};

--- a/burner/keyring/lib/message.js
+++ b/burner/keyring/lib/message.js
@@ -1,7 +1,6 @@
-import { provider } from "./starknet";
-import { toBN } from "starknet/utils/number";
 import { accountEventHandler } from "./handlers/account";
 import { keyringEventHandler } from "./handlers/keyring";
+import { providerEventHandler } from "./handlers/provider";
 
 const uuid = "589c80c1eb85413d";
 
@@ -32,31 +31,8 @@ export const eventHandler = async (event) => {
       return await accountEventHandler(type, data);
     case "keyring":
       return await keyringEventHandler(type, data);
-    default:
-      break;
-  }
-  switch (type) {
-    case "CALL_CONTRACT":
-      {
-        const { transactions, blockIdentifier } = data;
-        const { contractAddress, entrypoint, calldata } = transactions;
-        const newCall = {
-          contractAddress,
-          entrypoint,
-          calldata: [...calldata.map((v) => toBN(v).toString(10))],
-        };
-        console.log(newCall);
-        const output = await provider.callContract(newCall, blockIdentifier);
-        notify({ type: "CALL_CONTRACT_RES", data: output });
-      }
-      break;
-    case "GET_BLOCK":
-      {
-        const { blockIdentifier } = data;
-        const output = await provider.getBlock(blockIdentifier);
-        notify({ type: "GET_BLOCK_RES", data: output });
-      }
-      break;
+    case "provider":
+      return await providerEventHandler(type, data);
     default:
       break;
   }

--- a/burner/keyring/lib/starknet.js
+++ b/burner/keyring/lib/starknet.js
@@ -1,5 +1,0 @@
-import { Provider } from "starknet/provider";
-
-export const provider = new Provider({
-  sequencer: { network: "goerli-alpha" },
-});

--- a/starkpilled/package-lock.json
+++ b/starkpilled/package-lock.json
@@ -16,7 +16,7 @@
         "starknet": "^3.18.2"
       },
       "devDependencies": {
-        "@starknet/burner": "^0.2.99",
+        "@starknet/burner": "^0.2.100",
         "eslint": "8.21.0",
         "eslint-config-next": "12.2.3"
       }
@@ -444,9 +444,9 @@
       }
     },
     "node_modules/@starknet/burner": {
-      "version": "0.2.99",
-      "resolved": "https://registry.npmjs.org/@starknet/burner/-/burner-0.2.99.tgz",
-      "integrity": "sha512-CSGGL/w/Qk5NTt3XVcrrg4LdTXwKLUALzkIgiuxgeg7g76TF5u+gy9BuTiWqlQp2SUVr5naaGCLvkyBvX7KLVQ==",
+      "version": "0.2.100",
+      "resolved": "https://registry.npmjs.org/@starknet/burner/-/burner-0.2.100.tgz",
+      "integrity": "sha512-k74A/N/0NtS0TStYgGUlD8TC4Dp56PVwGBHYSfMzlhtLM8qm9ny4YlXufxv2Li/muau+9y5lgmIVyKNxxmJ8oQ==",
       "dev": true
     },
     "node_modules/@swc/helpers": {
@@ -3620,9 +3620,9 @@
       }
     },
     "@starknet/burner": {
-      "version": "0.2.99",
-      "resolved": "https://registry.npmjs.org/@starknet/burner/-/burner-0.2.99.tgz",
-      "integrity": "sha512-CSGGL/w/Qk5NTt3XVcrrg4LdTXwKLUALzkIgiuxgeg7g76TF5u+gy9BuTiWqlQp2SUVr5naaGCLvkyBvX7KLVQ==",
+      "version": "0.2.100",
+      "resolved": "https://registry.npmjs.org/@starknet/burner/-/burner-0.2.100.tgz",
+      "integrity": "sha512-k74A/N/0NtS0TStYgGUlD8TC4Dp56PVwGBHYSfMzlhtLM8qm9ny4YlXufxv2Li/muau+9y5lgmIVyKNxxmJ8oQ==",
       "dev": true
     },
     "@swc/helpers": {

--- a/starkpilled/package.json
+++ b/starkpilled/package.json
@@ -18,7 +18,7 @@
     "starknet": "^3.18.2"
   },
   "devDependencies": {
-    "@starknet/burner": "^0.2.99",
+    "@starknet/burner": "^0.2.100",
     "eslint": "8.21.0",
     "eslint-config-next": "12.2.3"
   }


### PR DESCRIPTION
This PR:
- change the event naming and organization to split between provider, signer and account
- implement the account in the extension and handle request/response to keyring
- implement the account in keyring (except for the key) and provide the response

What is missing in this side is:
- a complete set of tests
- the management of the account plugin