### PR TITLE
fix 👻 build with keyring postbuild

### DIFF
--- a/burner/keyring/scripts/postbuild.js
+++ b/burner/keyring/scripts/postbuild.js
@@ -1,4 +1,4 @@
-import fs from "fs";
+const fs = require("fs");
 
 fs.writeFileSync(
   "lib/version.js",


### PR DESCRIPTION
A bug in postbuild.js prevents the deployment of the starknet-builder on vercel