### PR TITLE
add dapp TokenID 🪅 with session request

### DIFF
--- a/drone/api/README.md
+++ b/drone/api/README.md
@@ -50,13 +50,26 @@ The service provides 2 ways of exchanging data:
 ```shell
 export BASEURL=https://...
 export REQUESTID=$(curl -XPOST ${BASEURL}/requests \
-  -d'{"sessionPublicKey": "0xdeadbeef", "dappTokenID": "0xdeadbeef"}' | \
+  -d'{"key": "0xdeadbeef", "dappTokenID": "0xdeadbeef"}' | \
    jq -r '.requestID')
 curl ${BASEURL}/requests/${REQUESTID}
 ```
 
 > Note: to store a request, you should specify both the public key and the
 > dappTokenID.
+
+```shell
+curl https://drone.carnage.sh/requests \
+  -d'{"key": "0x2", "dappTokenID": "0x3"}'
+
+# returns the output below
+# {"requestID":"960958","key":"0x2","dappTokenID":"0x3"}
+
+curl https://drone.carnage.sh/requests/960958
+
+# returns the output below
+# {"key": "0x2", "dappTokenID": "0x3"}
+```
 
 - storing/retrieving a session token
 

--- a/drone/api/README.md
+++ b/drone/api/README.md
@@ -50,10 +50,13 @@ The service provides 2 ways of exchanging data:
 ```shell
 export BASEURL=https://...
 export REQUESTID=$(curl -XPOST ${BASEURL}/requests \
-  -d'{"sessionPublicKey": "0xdeadbeef"}' | \
+  -d'{"sessionPublicKey": "0xdeadbeef", "dappTokenID": "0xdeadbeef"}' | \
    jq -r '.requestID')
 curl ${BASEURL}/requests/${REQUESTID}
 ```
+
+> Note: to store a request, you should specify both the public key and the
+> dappTokenID.
 
 - storing/retrieving a session token
 
@@ -61,10 +64,11 @@ curl ${BASEURL}/requests/${REQUESTID}
 export BASEURL=https://...
 curl -XPUT ${BASEURL}/0xdeadbeef \
   -d'{
-	"sessionPublicKey": "0xdeadbeef",
+	"key": "0xdeadbeef",
+  "policies": [{"contractAddress": "0xdeadbeef", "selector": "transfert"}],
 	"account": "0xdeadbeef",
-	"contract": "0xdeadbeef",
-	"token": ["0x1", "0x2"],
+	"root": "0xdeadbeef",
+	"signature": ["0x1", "0x2"],
 	"expires": 1659210039
   }'
 curl ${BASEURL}/0xdeadbeef

--- a/drone/api/data.go
+++ b/drone/api/data.go
@@ -22,7 +22,7 @@ import (
 
 type Request struct {
 	RequestID        string `dynamodbav:"requestID" json:"requestID"`
-	SessionPublicKey string `dynamodbav:"sessionPublicKey" json:"sessionPublicKey"`
+	SessionPublicKey string `dynamodbav:"sessionPublicKey" json:"key"`
 	DappTokenID      string `dynamodbav:"dappTokenID" json:"dappTokenID"`
 	TTL              int64  `dynamodbav:"TTL" json:"-"`
 }
@@ -164,7 +164,7 @@ func (pk *pathKeys) downloadRequest(ctx context.Context, request events.APIGatew
 	}
 	return events.APIGatewayV2HTTPResponse{
 		StatusCode: http.StatusOK,
-		Body:       fmt.Sprintf(`{"sessionPublicKey": "%s", "dappTokenID": "%s"}`, item.SessionPublicKey, item.DappTokenID),
+		Body:       fmt.Sprintf(`{"key": "%s", "dappTokenID": "%s"}`, item.SessionPublicKey, item.DappTokenID),
 		Headers:    map[string]string{"Content-Type": "application/json"},
 	}, nil
 }

--- a/drone/api/data.go
+++ b/drone/api/data.go
@@ -70,6 +70,7 @@ func (pk *pathKeys) uploadRequest(ctx context.Context, request events.APIGateway
 	}
 	sessionrequest := Request{}
 	err = json.Unmarshal(data, &sessionrequest)
+	fmt.Println("request", sessionrequest.SessionPublicKey, sessionrequest.DappTokenID)
 	if err != nil || sessionrequest.SessionPublicKey == "" || sessionrequest.DappTokenID == "" {
 		return events.APIGatewayV2HTTPResponse{
 			StatusCode: http.StatusBadRequest,
@@ -81,6 +82,7 @@ func (pk *pathKeys) uploadRequest(ctx context.Context, request events.APIGateway
 	nBig, _ := rand.Int(rand.Reader, big.NewInt(899999))
 	sessionrequest.RequestID = nBig.Add(nBig, big.NewInt(100000)).Text(10)
 	item, err := attributevalue.MarshalMap(sessionrequest)
+	fmt.Printf("item %+v", item)
 	if err != nil {
 		return events.APIGatewayV2HTTPResponse{
 			StatusCode: http.StatusInternalServerError,
@@ -162,7 +164,7 @@ func (pk *pathKeys) downloadRequest(ctx context.Context, request events.APIGatew
 	}
 	return events.APIGatewayV2HTTPResponse{
 		StatusCode: http.StatusOK,
-		Body:       fmt.Sprintf(`{"key": "%s"}`, item.SessionPublicKey),
+		Body:       fmt.Sprintf(`{"sessionPublicKey": "%s", "dappTokenID": "%s"}`, item.SessionPublicKey, item.DappTokenID),
 		Headers:    map[string]string{"Content-Type": "application/json"},
 	}, nil
 }


### PR DESCRIPTION
## Associated issue
To make sure the daoo will be identified, we will emit an NFT and reference it in the payload. This will enable us to get the policy
